### PR TITLE
Add {{ form.media }} in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ There are many ways to do this. I like doing this the following way:
     ```
     {% block non_admin_draftail_head %}
       {% include "non_admin_draftail/draftail_media.html" %}
+      {{ form.media }} # add this line if your template doesn't use "{{ form }}" but fields by themselves
     {% endblock non_admin_draftail_head %}
     ```
     And that's it, Draftail editor should now have all JS/CSS to boot up on the page.


### PR DESCRIPTION
Tried to follow your instructions to the letter. Was getting "window.draftail is not defined" error in my console and no editor was being displayed. After fidgeting a bit, I tried just adding {{ form }} to my page instead of {{ form.field }}{{ form.field }}... and {{ form.media }} at the end of my body tag. With {{ form }} it worked. So I took it off again and tried putting {{ form.media }} at different places until I put it after the html include and it worked.