### PR TITLE
Avoid RemovedInDjango41Warning on Django 3.2

### DIFF
--- a/non_admin_draftail/__init__.py
+++ b/non_admin_draftail/__init__.py
@@ -1,1 +1,5 @@
-default_app_config = "non_admin_draftail.apps.NonAdminDraftailConfig"
+import django
+
+
+if django.VERSION < (3, 2):
+      default_app_config = "non_admin_draftail.apps.NonAdminDraftailConfig"


### PR DESCRIPTION
Prevent this warning on Django 3.2:

```
  /.../django/apps/registry.py:91: RemovedInDjango41Warning: 'non_admin_draftail' defines default_app_config = 'non_admin_draftail.apps.NonAdminDraftailConfig'. Django now detects this configuration automatically. You can remove default_app_config.
    app_config = AppConfig.create(entry)
```

See also: https://docs.djangoproject.com/en/3.2/releases/3.2/#automatic-appconfig-discovery