### PR TITLE
Fix wagtailConfig.I18N_ENABLED

### DIFF
--- a/non_admin_draftail/templates/non_admin_draftail/_draftail_js.html
+++ b/non_admin_draftail/templates/non_admin_draftail/_draftail_js.html
@@ -66,6 +66,7 @@
     (function (document, window) {
         window.wagtailConfig = window.wagtailConfig || {};
         {% locales as locales %}
+        {% i18n_enabled as i18n_enabled %}
         wagtailConfig.I18N_ENABLED = {% if i18n_enabled %}true{% else %}false{% endif %};
         wagtailConfig.LOCALES = {{ locales|safe }};
         wagtailConfig.STRINGS = {% js_translation_strings %};


### PR DESCRIPTION
I have a "strict" template logging filter that errors for undefined variables. It disocvered that the `i18n_enabled` variable does not exist within this template.

Discovered that `i18n_enabled` is set to the return value of the tag with the same name inside Wagtail: https://github.com/wagtail/wagtail/blob/b297d521c1d838b4594aea565abf7215c30f1124/wagtail/admin/templates/wagtailadmin/admin_base.html#L32

This PR copies over that line.

Tested by making this change inside my local environment and seeing the strict template errors disappear.