### PR TITLE
fix modal-workflow.js path

### DIFF
--- a/non_admin_draftail/templates/non_admin_draftail/_draftail_js.html
+++ b/non_admin_draftail/templates/non_admin_draftail/_draftail_js.html
@@ -95,7 +95,7 @@
 {% hook_output 'insert_editor_js' %}
 
 {# We replace wagtailadmin/js/modal-workflow with the following file to add distinct css class to modal #}
-<script src="{% versioned_static 'non_admin_draftail//modal-workflow.js' %}"></script>
+<script src="{% versioned_static 'non_admin_draftail/modal-workflow.js' %}"></script>
 
 
 {# Override url callbacks for non-admin Draftail #}


### PR DESCRIPTION
After upgrading to the latest version this double slash is causing an error. I'm guessing because we use static manifest loader is why it was picked up, it's a bit more strict than the normal static loader